### PR TITLE
Support tupled input arguments

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -57,7 +57,7 @@ jobs:
           pip install -e .[tests]
       - name: Test with pytest
         run: |
-          pytest --cov=agjax agjax
+          pytest --cov=agjax tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/agjax/wrapper.py
+++ b/agjax/wrapper.py
@@ -85,14 +85,18 @@ def wrap_for_jax(
             nondiff_outputs, diff_outputs = split_outputs_fn(outputs)
             nondiff_outputs = _arraybox_to_numpy(nondiff_outputs)
             nondiff_outputs = tuple([_WrappedValue(o) for o in nondiff_outputs or []])
-            diff_outputs_leaves, diff_outputs_treedef = jax.tree_util.tree_flatten(diff_outputs)
+            diff_outputs_leaves, diff_outputs_treedef = jax.tree_util.tree_flatten(
+                diff_outputs
+            )
             return autograd.builtins.tuple(tuple(diff_outputs_leaves))
 
         diff_argnums = tuple(i for i in range(len(args)) if i not in _nondiff_argnums)
         tuple_vjp_fn, diff_outputs_leaves = autograd.make_vjp(
             _tuple_fn, argnum=diff_argnums
         )(*args)
-        diff_outputs = jax.tree_util.tree_unflatten(diff_outputs_treedef, diff_outputs_leaves)
+        diff_outputs = jax.tree_util.tree_unflatten(
+            diff_outputs_treedef, diff_outputs_leaves
+        )
         outputs = merge_outputs_fn(nondiff_outputs, _to_jax(diff_outputs))
         outputs = outputs if is_tuple_outputs else outputs[0]
 

--- a/agjax/wrapper.py
+++ b/agjax/wrapper.py
@@ -73,7 +73,7 @@ def wrap_for_jax(
         nondiff_outputs: Tuple[Any, ...] = None  # type: ignore[assignment]
         unflatten_outputs_fn: Callable[[onp.ndarray], Any] = None  # type: ignore[assignment]
 
-        def _flat_fn(*args) -> onp.ndarray:
+        def _flat_fn(*args: Any) -> onp.ndarray:
             nonlocal is_tuple_outputs
             nonlocal nondiff_outputs
             nonlocal unflatten_outputs_fn

--- a/agjax/wrapper.py
+++ b/agjax/wrapper.py
@@ -210,24 +210,6 @@ def _merge(
     )
 
 
-def _flatten(
-    tree: PyTree,
-) -> Tuple[onp.ndarray, Callable[[onp.ndarray], PyTree]]:
-    """Returns a pytree into a single numpy array, and an `unflatten_fn`."""
-    leaves, treedef = jax.tree_util.tree_flatten(tree)
-    flattened = npa.concatenate([leaf.flatten() for leaf in leaves])
-
-    sizes = [leaf.size for leaf in leaves]
-    shapes = [leaf.shape for leaf in leaves]
-
-    def unflatten_fn(flat: onp.ndarray) -> PyTree:
-        flat_leaves = npa.split(flat, onp.cumsum(sizes))
-        leaves = [leaf.reshape(s) for leaf, s in zip(flat_leaves, shapes)]
-        return jax.tree_util.tree_unflatten(treedef, leaves)
-
-    return flattened, unflatten_fn
-
-
 def _to_jax(tree: PyTree) -> PyTree:
     """Converts leaves of a pytree to jax arrays."""
     return jax.tree_util.tree_map(jnp.asarray, tree)

--- a/agjax/wrapper.py
+++ b/agjax/wrapper.py
@@ -69,9 +69,9 @@ def wrap_for_jax(
         args = merge_args_fn(nondiff_args, _to_numpy(diff_args))
 
         # Variables updated nonlocally where `fn` is evaluated.
-        is_tuple_outputs: bool = None  # type: ignore[misc]
-        nondiff_outputs: Tuple[Any, ...] = None  # type: ignore[misc]
-        unflatten_outputs_fn: Callable[[onp.ndarray], Any] = None  # type: ignore[misc]
+        is_tuple_outputs: bool = None  # type: ignore[assignment]
+        nondiff_outputs: Tuple[Any, ...] = None  # type: ignore[assignment]
+        unflatten_outputs_fn: Callable[[onp.ndarray], Any] = None  # type: ignore[assignment]
 
         def _flat_fn(*args) -> onp.ndarray:
             nonlocal is_tuple_outputs

--- a/agjax/wrapper.py
+++ b/agjax/wrapper.py
@@ -71,7 +71,7 @@ def wrap_for_jax(
         # Variables updated nonlocally where `fn` is evaluated.
         is_tuple_outputs: bool = None  # type: ignore[assignment]
         nondiff_outputs: Tuple[Any, ...] = None  # type: ignore[assignment]
-        diff_outputs_treedef: jax.tree_util.PyTreeDef = None  # type: ignore[assignment]
+        diff_outputs_treedef: jax.tree_util.PyTreeDef = None
 
         def _tuple_fn(*args: Any) -> onp.ndarray:
             nonlocal is_tuple_outputs

--- a/docs/photonic_inverse_design.ipynb
+++ b/docs/photonic_inverse_design.ipynb
@@ -108,7 +108,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "082bf74f",
    "metadata": {},

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -191,6 +191,10 @@ class WrappedValueTest(unittest.TestCase):
         restored = jax.tree_util.tree_unflatten(treedef, leaves)
         self.assertSequenceEqual(restored.value, (1, 2, 3, 4))
 
+    def test_wrapped_repr(self):
+        wrapped = wrapper._WrappedValue(value="my_string")
+        self.assertSequenceEqual(str(wrapped), "_WrappedValue(my_string)")
+
 
 class ValidateIdxTest(unittest.TestCase):
     @parameterized.parameterized.expand(

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -22,6 +22,10 @@ TEST_FNS_AND_ARGS = (
         lambda x, y: x**2 + y,
         (3.0, 4.0),
     ),
+    (  # Two arguments, scalar output wrapped in a tuple.
+        lambda x, y: (x**2 + y,),
+        (3.0, 4.0),
+    ),
     (  # Two arguments, two outputs.
         lambda x, y: (x**2 + y, x - y),
         (3.0, 4.0),


### PR DESCRIPTION
As raised in https://github.com/mfschubert/agjax/issues/10, we can rely on some built-in features of autograd to handle multiple input arguments and outputs. Here we make use of these autograd features rather than manual flattening as done previously.