### PR TITLE
Remove jax types from pure callback fns

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.3.2"
+current_version = "v0.3.3"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,6 +31,7 @@ jobs:
 
   validate-types-and-docstrings:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,6 +58,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -78,6 +81,7 @@ jobs:
 
   test_docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     needs: [pre-commit]
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Agjax -- jax wrapper for autograd-differentiable functions.
-`v0.3.2`
+`v0.3.3`
 
 Agjax allows existing code built with autograd to be used with the jax framework.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 
 dependencies = [
     "autograd",
-    "jax",
+    "jax <= 0.4.31",
     "jaxlib",
     "numpy~=1.25",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "agjax"
-version = "v0.3.2"
+version = "v0.3.3"
 description = "A jax wrapper for autograd-differentiable functions."
 keywords = ["autograd", "jax", "python", "wrapper", "gradient"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 
 dependencies = [
     "autograd",
-    "jax <= 0.4.31",
+    "jax <= 0.4.35",
     "jaxlib",
     "numpy~=1.25",
 ]

--- a/src/agjax/__init__.py
+++ b/src/agjax/__init__.py
@@ -1,6 +1,6 @@
 """agjax - a jax wrapper for autograd-differentiable functions."""
 
-__version__ = "v0.3.2"
+__version__ = "v0.3.3"
 __author__ = "Martin Schubert <mfschubert@gmail.com>"
 
 __all__ = ["experimental", "wrap_for_jax"]

--- a/src/agjax/experimental/wrapper.py
+++ b/src/agjax/experimental/wrapper.py
@@ -111,17 +111,17 @@ def wrap_for_jax(
             diff_outputs = tree_util.tree_unflatten(
                 diff_outputs_treedef, diff_outputs_leaves
             )
-            outputs = utils.to_jax(merge_outputs_fn(nondiff_outputs, diff_outputs))
+            outputs = merge_outputs_fn(nondiff_outputs, diff_outputs)
             outputs = outputs if is_tuple_outputs else outputs[0]
 
             def _vjp_fn(*diff_outputs: Any) -> Any:
                 diff_outputs_leaves = tree_util.tree_leaves(diff_outputs)
                 grad = tuple_vjp_fn(utils.to_numpy(diff_outputs_leaves))
-                return utils.to_jax(grad)
+                return grad
 
             key = len(vjp_fns)
             vjp_fns.append(tree_util.Partial(_vjp_fn))
-            return outputs, jnp.asarray(key)
+            return outputs, key
 
         outputs, key = jax.pure_callback(
             make_vjp,

--- a/src/agjax/experimental/wrapper.py
+++ b/src/agjax/experimental/wrapper.py
@@ -135,7 +135,7 @@ def wrap_for_jax(
             nonlocal stage
             stage = _BACKWARD_STAGE
             vjp_fn = vjp_fns[int(key)]
-            return utils.to_jax(vjp_fn(utils.to_numpy(*tangents)))
+            return vjp_fn(utils.to_numpy(*tangents))
 
         (args, key), *tangents = bwd_args
         _, diff_args = split_args_fn(args)


### PR DESCRIPTION
Jax types in pure callback fns seem to be the cause of flakiness and hanging for jax versions newer than 0.4.31. For example, the test docs CI action has started failing since the jax update.

This PR removes jax types from the pure callback, which seems to resolve all issues.